### PR TITLE
Use `eval.parent` instead of `eval`

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -56,7 +56,7 @@ from <- function(.from, ..., .into = "imports")
                        if (use_into) symbol_as_character(into),
                        names(symbols)[s])
 
-    eval(import_call, parent, parent)
+    eval.parent(import_call)
   }
 
   invisible(NULL)
@@ -66,9 +66,8 @@ from <- function(.from, ..., .into = "imports")
 #' @export
 into <- function(.into, ..., .from)
 {
-  parent <- parent.frame()
   cl <- match.call()
   cl[[1L]] <- quote(import::from)
-  eval(cl, parent, parent)
+  eval.parent(cl)
 }
 


### PR DESCRIPTION
The code can be simplified ever so slightly by using `eval.parent` instead of
`eval`. Furthermore, the last argument (`enclos`) is unnecessary since it’s
only relevant for non-environment objects (i.e. lists or data.frames), not when
evaluating inside an environment (which has its own enclosing environment).

This PR is essentially expert bikeshedding.