### PR TITLE
Set default `.library` via `options`

### DIFF
--- a/R/from.R
+++ b/R/from.R
@@ -40,6 +40,20 @@
 #' You can use the operators \code{<}, \code{>}, \code{<=}, \code{>=},
 #' \code{==}, \code{!=}. Whitespace in the specification is irrelevant.
 #'
+#' @section Package Libraries:
+#' The search path for packages is specified by the \code{.library}
+#' argument to \code{import::from}. By default, this grabs the
+#' library location from the \code{import.library} option, which in
+#' turn defaults to the first entry in \code{.libPaths()}. You can
+#' customize the default behavior by changing this option. For
+#' instance, to search all of \code{.libPaths()}, you could do:
+#'
+#' \preformatted{
+#'   options("import.library" = .libPaths())
+#' }
+#'
+#' A convenient place to do this is in a global or directory-specific ".Rprofile".
+#'
 #' @rdname importfunctions
 #' @param .from The package from which to import.
 #' @param ... Names or name-value pairs specifying objects to import.
@@ -47,7 +61,7 @@
 #' @param .into The name of the search path entry. Use \code{""} to import
 #'   into the current environment.
 #' @param .library character specifying the library to use. Defaults to
-#'   the latest specified library.
+#'   \code{getOption("import.library")}.
 #' @param .character_only A logical indicating whether \code{.from} and
 #'   \code{...} can be assumed to be charater strings.
 #'
@@ -58,7 +72,7 @@
 #' @examples
 #' import::from(parallel, makeCluster, parLapply)
 #' import::into("imports:parallel", makeCluster, parLapply, .from = parallel)
-from <- function(.from, ..., .into = "imports", .library = .libPaths()[1L],
+from <- function(.from, ..., .into = "imports", .library = getOption("import.library"),
                  .character_only = FALSE)
 {
   # Capture the relevant part of the call to see if

--- a/R/here.R
+++ b/R/here.R
@@ -1,6 +1,6 @@
 #' @rdname importfunctions
 #' @export
-here <- function(..., .from, .library = .libPaths()[1L],
+here <- function(..., .from, .library = getOption("import.library"),
                  .character_only = FALSE)
 {
   # Capture the call and check that it is valid.

--- a/R/into.R
+++ b/R/into.R
@@ -1,6 +1,6 @@
 #' @rdname importfunctions
 #' @export
-into <- function(.into, ..., .from, .library = .libPaths()[1L],
+into <- function(.into, ..., .from, .library = getOption("import.library"),
                  .character_only = FALSE)
 {
   # Capture the call and check that it is valid.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,3 +10,9 @@
 
   invisible()
 }
+
+.onLoad <- function(libname, pkgname) {
+  options(
+    "import.library" = .libPaths()[1L]
+  )
+}

--- a/man/importfunctions.Rd
+++ b/man/importfunctions.Rd
@@ -6,12 +6,14 @@
 \alias{into}
 \title{Import Objects From a Package.}
 \usage{
-from(.from, ..., .into = "imports", .library = .libPaths()[1L],
+from(.from, ..., .into = "imports",
+  .library = getOption("import.library"), .character_only = FALSE)
+
+here(..., .from, .library = getOption("import.library"),
   .character_only = FALSE)
 
-here(..., .from, .library = .libPaths()[1L], .character_only = FALSE)
-
-into(.into, ..., .from, .library = .libPaths()[1L], .character_only = FALSE)
+into(.into, ..., .from, .library = getOption("import.library"),
+  .character_only = FALSE)
 }
 \arguments{
 \item{.from}{The package from which to import.}
@@ -23,7 +25,7 @@ If arguments are named, then the imported object will have this new name.}
 into the current environment.}
 
 \item{.library}{character specifying the library to use. Defaults to
-the latest specified library.}
+\code{getOption("import.library")}.}
 
 \item{.character_only}{A logical indicating whether \code{.from} and
 \code{...} can be assumed to be charater strings.}
@@ -74,6 +76,22 @@ add a requirement in parentheses to the package name (which then needs to
 be quoted), e.g \code{import::from("parallel (>= 3.2.0)", ...)}.
 You can use the operators \code{<}, \code{>}, \code{<=}, \code{>=},
 \code{==}, \code{!=}. Whitespace in the specification is irrelevant.
+}
+
+\section{Package Libraries}{
+
+The search path for packages is specified by the \code{.library}
+argument to \code{import::from}. By default, this grabs the
+library location from the \code{import.library} option, which in
+turn defaults to the first entry in \code{.libPaths()}. You can
+customize the default behavior by changing this option. For
+instance, to search all of \code{.libPaths()}, you could do:
+
+\preformatted{
+  options("import.library" = .libPaths())
+}
+
+A convenient place to do this is in a global or directory-specific ".Rprofile".
 }
 
 \examples{


### PR DESCRIPTION
This makes it easier to run the same code on multiple machines, while still maintaining strictness where necessary. See also #10.

Importantly, the default behavior of this package should be _exactly the same_, as is the behavior when `.library` is set explicitly.